### PR TITLE
Feature/criteria set

### DIFF
--- a/.idea/sqldialects.xml
+++ b/.idea/sqldialects.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="SqlDialectMappings">
+    <file url="PROJECT" dialect="PostgreSQL" />
+  </component>
+</project>

--- a/src/main/java/com/a6raywa1cher/coursejournalbackend/model/Criteria.java
+++ b/src/main/java/com/a6raywa1cher/coursejournalbackend/model/Criteria.java
@@ -11,10 +11,12 @@ import org.springframework.data.annotation.ReadOnlyProperty;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 @Entity
-@Table(name = "criteria", uniqueConstraints = @UniqueConstraint(columnNames = {"task_id", "name"}))
+@Table(name = "criteria", uniqueConstraints = @UniqueConstraint(name = "criteria_task_name_uniq", columnNames = {"task_id", "name"}))
 @Getter
 @Setter
 @ToString
@@ -35,6 +37,10 @@ public class Criteria implements IdEntity<Long> {
 
     @Column(name = "criteria_percent")
     private Integer criteriaPercent;
+
+    @ManyToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE}, mappedBy = "satisfiedCriteria")
+    @ToString.Exclude
+    private List<Submission> submissionList = new ArrayList<>();
 
     @Column(name = "created_at")
     @CreatedDate

--- a/src/main/java/com/a6raywa1cher/coursejournalbackend/model/repo/CriteriaRepository.java
+++ b/src/main/java/com/a6raywa1cher/coursejournalbackend/model/repo/CriteriaRepository.java
@@ -2,12 +2,15 @@ package com.a6raywa1cher.coursejournalbackend.model.repo;
 
 import com.a6raywa1cher.coursejournalbackend.model.Criteria;
 import com.a6raywa1cher.coursejournalbackend.model.Task;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
-public interface CriteriaRepository extends CrudRepository<Criteria, Long> {
+public interface CriteriaRepository extends JpaRepository<Criteria, Long>, CustomCriteriaRepository {
     List<Criteria> getAllByTask(Task task);
+
+    List<Criteria> getAllByTask(Task task, Sort sort);
 }

--- a/src/main/java/com/a6raywa1cher/coursejournalbackend/model/repo/CustomCriteriaRepository.java
+++ b/src/main/java/com/a6raywa1cher/coursejournalbackend/model/repo/CustomCriteriaRepository.java
@@ -1,0 +1,9 @@
+package com.a6raywa1cher.coursejournalbackend.model.repo;
+
+import com.a6raywa1cher.coursejournalbackend.model.Criteria;
+
+import java.util.List;
+
+public interface CustomCriteriaRepository {
+    List<Criteria> saveAllForTaskWithRename(List<Criteria> criteriaList);
+}

--- a/src/main/java/com/a6raywa1cher/coursejournalbackend/model/repo/CustomCriteriaRepositoryImpl.java
+++ b/src/main/java/com/a6raywa1cher/coursejournalbackend/model/repo/CustomCriteriaRepositoryImpl.java
@@ -22,7 +22,11 @@ public class CustomCriteriaRepositoryImpl implements CustomCriteriaRepository {
         for (int i = 0; i < criteriaList.size(); i++) {
             Criteria criteria = criteriaList.get(i);
             names.put(criteria, criteria.getName());
-            criteria.setName("tmp" + i);
+
+            // unique constraint bypass: criteriaList contains all criteria for the task
+            // therefore we can rename all of them to some dummy string
+            // $tmp0, ... will not occur in db since dollar sign isn't allowed
+            criteria.setName("$tmp" + i);
         }
         criteriaList.forEach(em::merge);
         em.flush();

--- a/src/main/java/com/a6raywa1cher/coursejournalbackend/model/repo/CustomCriteriaRepositoryImpl.java
+++ b/src/main/java/com/a6raywa1cher/coursejournalbackend/model/repo/CustomCriteriaRepositoryImpl.java
@@ -1,0 +1,35 @@
+package com.a6raywa1cher.coursejournalbackend.model.repo;
+
+import com.a6raywa1cher.coursejournalbackend.model.Criteria;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Repository
+public class CustomCriteriaRepositoryImpl implements CustomCriteriaRepository {
+    private final EntityManager em;
+
+    public CustomCriteriaRepositoryImpl(EntityManager em) {
+        this.em = em;
+    }
+
+    @Override
+    public List<Criteria> saveAllForTaskWithRename(List<Criteria> criteriaList) {
+        Map<Criteria, String> names = new HashMap<>();
+        for (int i = 0; i < criteriaList.size(); i++) {
+            Criteria criteria = criteriaList.get(i);
+            names.put(criteria, criteria.getName());
+            criteria.setName("tmp" + i);
+        }
+        criteriaList.forEach(em::merge);
+        em.flush();
+        return criteriaList
+                .stream()
+                .peek(c -> c.setName(names.get(c)))
+                .map(em::merge)
+                .toList();
+    }
+}

--- a/src/main/java/com/a6raywa1cher/coursejournalbackend/rest/CriteriaController.java
+++ b/src/main/java/com/a6raywa1cher/coursejournalbackend/rest/CriteriaController.java
@@ -1,6 +1,7 @@
 package com.a6raywa1cher.coursejournalbackend.rest;
 
 import com.a6raywa1cher.coursejournalbackend.dto.CriteriaDto;
+import com.a6raywa1cher.coursejournalbackend.rest.dto.BatchSetForTaskCriteriaDto;
 import com.a6raywa1cher.coursejournalbackend.rest.dto.CriteriaRestDto;
 import com.a6raywa1cher.coursejournalbackend.rest.dto.MapStructRestDtoMapper;
 import com.a6raywa1cher.coursejournalbackend.rest.dto.groups.OnCreate;
@@ -39,7 +40,7 @@ public class CriteriaController {
     @PreAuthorize("@accessChecker.readTaskAccess(#id, authentication)")
     public List<CriteriaDto> getByTask(@PathVariable long id) {
         return service.getByTaskId(id).stream()
-                .sorted(Comparator.comparing(CriteriaDto::getCriteriaPercent))
+                .sorted(Comparator.comparing(CriteriaDto::getId))
                 .toList();
     }
 
@@ -56,6 +57,12 @@ public class CriteriaController {
     @Validated(OnUpdate.class)
     public CriteriaDto update(@RequestBody @Valid CriteriaRestDto dto, @PathVariable long id) {
         return service.update(id, mapper.map(dto));
+    }
+
+    @PostMapping("/task/{id}/set")
+    @PreAuthorize("@accessChecker.editTaskAccess(#id, authentication)")
+    public List<CriteriaDto> setForTask(@RequestBody @Valid BatchSetForTaskCriteriaDto dto, @PathVariable long id) {
+        return service.setForTask(id, dto.getCriteria().stream().map(mapper::map).toList());
     }
 
     @PatchMapping("/{id}")

--- a/src/main/java/com/a6raywa1cher/coursejournalbackend/rest/dto/BatchSetForTaskCriteriaDto.java
+++ b/src/main/java/com/a6raywa1cher/coursejournalbackend/rest/dto/BatchSetForTaskCriteriaDto.java
@@ -1,0 +1,28 @@
+package com.a6raywa1cher.coursejournalbackend.rest.dto;
+
+import com.a6raywa1cher.coursejournalbackend.validation.UniqueByName;
+import lombok.Data;
+
+import javax.validation.constraints.*;
+import java.util.List;
+
+import static com.a6raywa1cher.coursejournalbackend.validation.RegexLibrary.COMMON_NAME;
+
+@Data
+public class BatchSetForTaskCriteriaDto {
+    @NotNull
+    @UniqueByName
+    private List<CriteriaSetForTaskDto> criteria;
+
+    @Data
+    public static final class CriteriaSetForTaskDto {
+        @NotBlank
+        @Pattern(regexp = COMMON_NAME)
+        private String name;
+
+        @NotNull
+        @Min(0)
+        @Max(100)
+        private Integer criteriaPercent;
+    }
+}

--- a/src/main/java/com/a6raywa1cher/coursejournalbackend/rest/dto/BatchSetForTaskCriteriaDto.java
+++ b/src/main/java/com/a6raywa1cher/coursejournalbackend/rest/dto/BatchSetForTaskCriteriaDto.java
@@ -6,7 +6,7 @@ import lombok.Data;
 import javax.validation.constraints.*;
 import java.util.List;
 
-import static com.a6raywa1cher.coursejournalbackend.validation.RegexLibrary.COMMON_NAME;
+import static com.a6raywa1cher.coursejournalbackend.validation.RegexLibrary.CRITERIA_NAME;
 
 @Data
 public class BatchSetForTaskCriteriaDto {
@@ -17,7 +17,7 @@ public class BatchSetForTaskCriteriaDto {
     @Data
     public static final class CriteriaSetForTaskDto {
         @NotBlank
-        @Pattern(regexp = COMMON_NAME)
+        @Pattern(regexp = CRITERIA_NAME)
         private String name;
 
         @NotNull

--- a/src/main/java/com/a6raywa1cher/coursejournalbackend/rest/dto/CriteriaRestDto.java
+++ b/src/main/java/com/a6raywa1cher/coursejournalbackend/rest/dto/CriteriaRestDto.java
@@ -6,7 +6,7 @@ import lombok.Data;
 
 import javax.validation.constraints.*;
 
-import static com.a6raywa1cher.coursejournalbackend.validation.RegexLibrary.COMMON_NAME;
+import static com.a6raywa1cher.coursejournalbackend.validation.RegexLibrary.CRITERIA_NAME;
 
 @Data
 public class CriteriaRestDto {
@@ -15,7 +15,7 @@ public class CriteriaRestDto {
     private Long task;
 
     @NotBlank(groups = {OnCreate.class, OnUpdate.class})
-    @Pattern(regexp = COMMON_NAME)
+    @Pattern(regexp = CRITERIA_NAME)
     private String name;
 
     @NotNull(groups = {OnCreate.class, OnUpdate.class})

--- a/src/main/java/com/a6raywa1cher/coursejournalbackend/rest/dto/MapStructRestDtoMapper.java
+++ b/src/main/java/com/a6raywa1cher/coursejournalbackend/rest/dto/MapStructRestDtoMapper.java
@@ -34,12 +34,20 @@ public interface MapStructRestDtoMapper {
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "lastModifiedAt", ignore = true)
+    @Mapping(target = "task", ignore = true)
+    CriteriaDto map(BatchSetForTaskCriteriaDto.CriteriaSetForTaskDto dto);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "lastModifiedAt", ignore = true)
+    @Mapping(target = "headman", ignore = true)
     StudentDto map(StudentRestDto dto);
 
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "lastModifiedAt", ignore = true)
     @Mapping(target = "group", ignore = true)
+    @Mapping(target = "headman", ignore = true)
     StudentDto map(BatchCreateStudentDto.StudentInfo studentInfo);
 
     @Mapping(target = "id", ignore = true)
@@ -79,5 +87,6 @@ public interface MapStructRestDtoMapper {
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "lastModifiedAt", ignore = true)
+    @Mapping(target = "hasAuthUser", ignore = true)
     EmployeeDto map(EmployeeRestDto dto);
 }

--- a/src/main/java/com/a6raywa1cher/coursejournalbackend/service/CriteriaService.java
+++ b/src/main/java/com/a6raywa1cher/coursejournalbackend/service/CriteriaService.java
@@ -19,6 +19,8 @@ public interface CriteriaService {
 
     CriteriaDto update(long id, CriteriaDto dto);
 
+    List<CriteriaDto> setForTask(long taskId, List<CriteriaDto> criteriaDtoList);
+
     CriteriaDto patch(long id, CriteriaDto dto);
 
     void delete(long id);

--- a/src/main/java/com/a6raywa1cher/coursejournalbackend/service/impl/CriteriaServiceImpl.java
+++ b/src/main/java/com/a6raywa1cher/coursejournalbackend/service/impl/CriteriaServiceImpl.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 @Service
 @Transactional
@@ -52,7 +51,7 @@ public class CriteriaServiceImpl implements CriteriaService {
 
     @Override
     public List<Criteria> findRawById(List<Long> ids) {
-        return StreamSupport.stream(repository.findAllById(ids).spliterator(), false).toList();
+        return repository.findAllById(ids).stream().toList();
     }
 
     @Override

--- a/src/main/java/com/a6raywa1cher/coursejournalbackend/service/impl/CriteriaServiceImpl.java
+++ b/src/main/java/com/a6raywa1cher/coursejournalbackend/service/impl/CriteriaServiceImpl.java
@@ -190,7 +190,7 @@ public class CriteriaServiceImpl implements CriteriaService {
 
     private void assertNoTaskChange(Criteria criteria, Task newTask) {
         if (!Objects.equals(criteria.getTask(), newTask)) {
-            throw new TransferNotAllowedException(Criteria.class, "task", criteria.getTask().getId(), newTask.getId());
+            throw new TransferNotAllowedException(Criteria.class, "task", criteria.getTask(), newTask);
         }
     }
 

--- a/src/main/java/com/a6raywa1cher/coursejournalbackend/service/impl/CriteriaServiceImpl.java
+++ b/src/main/java/com/a6raywa1cher/coursejournalbackend/service/impl/CriteriaServiceImpl.java
@@ -13,13 +13,16 @@ import com.a6raywa1cher.coursejournalbackend.service.SubmissionService;
 import com.a6raywa1cher.coursejournalbackend.service.TaskService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 @Service
@@ -94,6 +97,47 @@ public class CriteriaServiceImpl implements CriteriaService {
     }
 
     @Override
+    public List<CriteriaDto> setForTask(long taskId, List<CriteriaDto> criteriaDtoList) {
+        Task task = getTaskById(taskId);
+        List<Criteria> existingCriteria = repository.getAllByTask(task, Sort.by(Sort.Order.asc("id")));
+        int inputSize = criteriaDtoList.size();
+        int dbSize = existingCriteria.size();
+        List<Criteria> toCreate = new ArrayList<>();
+        List<Criteria> toSave = new ArrayList<>();
+        List<Criteria> toDelete = new ArrayList<>();
+        LocalDateTime now = LocalDateTime.now();
+        for (int i = 0; i < Math.max(inputSize, dbSize); i++) {
+            if (i < inputSize && i < dbSize) {
+                CriteriaDto input = criteriaDtoList.get(i);
+                Criteria db = existingCriteria.get(i);
+                mapper.put(input, db);
+                db.setLastModifiedAt(now);
+                toSave.add(db);
+            } else if (i < inputSize) {
+                CriteriaDto input = criteriaDtoList.get(i);
+                Criteria criteria = new Criteria();
+                mapper.put(input, criteria);
+                criteria.setTask(task);
+                criteria.setCreatedAt(now);
+                criteria.setLastModifiedAt(now);
+                toCreate.add(criteria);
+            } else {
+                Criteria db = existingCriteria.get(i);
+                db.getSubmissionList().forEach(s -> s.getSatisfiedCriteria().remove(db));
+                db.getSubmissionList().clear();
+                toDelete.add(db);
+            }
+        }
+        repository.deleteAll(toDelete);
+        return Stream.concat(
+                        repository.saveAllForTaskWithRename(toSave).stream(),
+                        repository.saveAll(toCreate).stream()
+                )
+                .map(mapper::map)
+                .toList();
+    }
+
+    @Override
     public CriteriaDto patch(long id, CriteriaDto dto) {
         Criteria criteria = getCriteriaById(id);
         Task task = dto.getTask() != null ? getTaskById(dto.getTask()) : criteria.getTask();
@@ -114,6 +158,8 @@ public class CriteriaServiceImpl implements CriteriaService {
     @Override
     public void delete(long id) {
         Criteria criteria = getCriteriaById(id);
+        criteria.getSubmissionList().forEach(s -> s.getSatisfiedCriteria().remove(criteria));
+        criteria.getSubmissionList().clear();
         repository.delete(criteria);
     }
 

--- a/src/main/java/com/a6raywa1cher/coursejournalbackend/service/impl/SubmissionServiceImpl.java
+++ b/src/main/java/com/a6raywa1cher/coursejournalbackend/service/impl/SubmissionServiceImpl.java
@@ -239,7 +239,6 @@ public class SubmissionServiceImpl implements SubmissionService {
     }
 
     private void setSatisfiedCriteria(Submission submission, List<Criteria> satisfiedCriteria) {
-//        submission.setSatisfiedCriteria(new ArrayList<>(satisfiedCriteria));
         submission.setSatisfiedCriteria(satisfiedCriteria);
         satisfiedCriteria.forEach(c -> c.getSubmissionList().add(submission));
     }

--- a/src/main/java/com/a6raywa1cher/coursejournalbackend/service/impl/SubmissionServiceImpl.java
+++ b/src/main/java/com/a6raywa1cher/coursejournalbackend/service/impl/SubmissionServiceImpl.java
@@ -107,7 +107,7 @@ public class SubmissionServiceImpl implements SubmissionService {
 
         submission.setTask(task);
         submission.setStudent(student);
-        submission.setSatisfiedCriteria(satisfiedCriteria);
+        setSatisfiedCriteria(submission, satisfiedCriteria);
         submission.setMainScore(scoringService.getMainScore(
                 mapper.map(submission),
                 mapper.map(task),
@@ -130,7 +130,7 @@ public class SubmissionServiceImpl implements SubmissionService {
         assertSameCourseAndTask(satisfiedCriteria, task, student);
         mapper.put(dto, submission);
 
-        submission.setSatisfiedCriteria(new ArrayList<>(satisfiedCriteria));
+        setSatisfiedCriteria(submission, satisfiedCriteria);
         submission.setMainScore(scoringService.getMainScore(
                 mapper.map(submission),
                 mapper.map(task),
@@ -154,7 +154,7 @@ public class SubmissionServiceImpl implements SubmissionService {
         assertSameCourseAndTask(satisfiedCriteria, task, student);
         mapper.patch(dto, submission);
 
-        submission.setSatisfiedCriteria(new ArrayList<>(satisfiedCriteria));
+        setSatisfiedCriteria(submission, satisfiedCriteria);
         submission.setMainScore(scoringService.getMainScore(
                 mapper.map(submission),
                 mapper.map(task),
@@ -167,6 +167,8 @@ public class SubmissionServiceImpl implements SubmissionService {
     @Override
     public void delete(long id) {
         Submission submission = getSubmissionById(id);
+        submission.getSatisfiedCriteria().forEach(c -> c.getSubmissionList().remove(submission));
+        submission.getSatisfiedCriteria().clear();
         repository.delete(submission);
     }
 
@@ -234,6 +236,12 @@ public class SubmissionServiceImpl implements SubmissionService {
                     "task", Long.toString(task.getId()),
                     "student", Long.toString(student.getId()));
         }
+    }
+
+    private void setSatisfiedCriteria(Submission submission, List<Criteria> satisfiedCriteria) {
+//        submission.setSatisfiedCriteria(new ArrayList<>(satisfiedCriteria));
+        submission.setSatisfiedCriteria(satisfiedCriteria);
+        satisfiedCriteria.forEach(c -> c.getSubmissionList().add(submission));
     }
 
     @Autowired

--- a/src/main/java/com/a6raywa1cher/coursejournalbackend/validation/RegexLibrary.java
+++ b/src/main/java/com/a6raywa1cher/coursejournalbackend/validation/RegexLibrary.java
@@ -6,4 +6,6 @@ public final class RegexLibrary {
     public static final String COMMON_NAME = "^.{1,250}$";
 
     public static final String COMMON_DESCRIPTION = "^.{1,25000}$";
+
+    public static final String CRITERIA_NAME = "^[^$]{1,150}$";
 }

--- a/src/main/java/com/a6raywa1cher/coursejournalbackend/validation/UniqueByName.java
+++ b/src/main/java/com/a6raywa1cher/coursejournalbackend/validation/UniqueByName.java
@@ -1,0 +1,20 @@
+package com.a6raywa1cher.coursejournalbackend.validation;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+
+@Constraint(validatedBy = UniqueByNameValidator.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target(FIELD)
+public @interface UniqueByName {
+    String message() default "List cannot contain same name twice";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/a6raywa1cher/coursejournalbackend/validation/UniqueByNameValidator.java
+++ b/src/main/java/com/a6raywa1cher/coursejournalbackend/validation/UniqueByNameValidator.java
@@ -1,0 +1,23 @@
+package com.a6raywa1cher.coursejournalbackend.validation;
+
+import com.a6raywa1cher.coursejournalbackend.rest.dto.BatchSetForTaskCriteriaDto;
+import org.springframework.stereotype.Component;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+public class UniqueByNameValidator implements ConstraintValidator<UniqueByName,
+        List<BatchSetForTaskCriteriaDto.CriteriaSetForTaskDto>> {
+    @Override
+    public boolean isValid(List<BatchSetForTaskCriteriaDto.CriteriaSetForTaskDto> value, ConstraintValidatorContext context) {
+        if (value == null) return true;
+        Set<?> set = value.stream()
+                .map(BatchSetForTaskCriteriaDto.CriteriaSetForTaskDto::getName)
+                .collect(Collectors.toSet());
+        return value.size() == set.size();
+    }
+}

--- a/src/test/java/com/a6raywa1cher/coursejournalbackend/ObjectRequestContext.java
+++ b/src/test/java/com/a6raywa1cher/coursejournalbackend/ObjectRequestContext.java
@@ -1,0 +1,51 @@
+package com.a6raywa1cher.coursejournalbackend;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.test.web.servlet.ResultMatcher;
+
+import java.util.function.Function;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class ObjectRequestContext<T, J> {
+    private final T request;
+
+    private final Function<String, ResultMatcher[]> matchersSupplier;
+
+    private final J data;
+
+    public ObjectRequestContext(T request) {
+        this.request = request;
+        this.matchersSupplier = prefix -> new ResultMatcher[0];
+        this.data = null;
+    }
+
+    public ObjectRequestContext(T request, Function<String, ResultMatcher[]> matchersSupplier) {
+        this.request = request;
+        this.matchersSupplier = matchersSupplier;
+        this.data = null;
+    }
+
+    public ObjectRequestContext(T request, J data) {
+        this.request = request;
+        this.matchersSupplier = prefix -> new ResultMatcher[0];
+        this.data = data;
+    }
+
+    public ObjectRequestContext(T request, J data, Function<String, ResultMatcher[]> matchersSupplier) {
+        this.request = request;
+        this.matchersSupplier = matchersSupplier;
+        this.data = data;
+    }
+
+    public ResultMatcher[] getMatchers() {
+        return getMatchers("$");
+    }
+
+    public ResultMatcher[] getMatchers(String prefix) {
+        return matchersSupplier.apply(prefix);
+    }
+}

--- a/src/test/java/com/a6raywa1cher/coursejournalbackend/integration/models/CriteriaInfo.java
+++ b/src/test/java/com/a6raywa1cher/coursejournalbackend/integration/models/CriteriaInfo.java
@@ -1,0 +1,4 @@
+package com.a6raywa1cher.coursejournalbackend.integration.models;
+
+public record CriteriaInfo(String name, Integer criteriaPercent) {
+}

--- a/src/test/java/com/a6raywa1cher/coursejournalbackend/integration/models/GetSetForTaskData.java
+++ b/src/test/java/com/a6raywa1cher/coursejournalbackend/integration/models/GetSetForTaskData.java
@@ -1,0 +1,6 @@
+package com.a6raywa1cher.coursejournalbackend.integration.models;
+
+import java.util.List;
+
+public record GetSetForTaskData(long submissionId, long taskId, List<Long> criteria) {
+}


### PR DESCRIPTION
Данный PR добавляет `POST /criteria/task/{id}/set`, который принимает список критериев, которые клиент хочет, чтобы в точности были у данного `Task` и применяет эти изменения.

Логика процесса основана на переиспользовании имеющихся `Criteria` с целью сохранения уже выставленных `satisfiedCriteria`. Порядок сопоставления: id критерия в порядке возрастания <-> индекс критерия в запросе. В итоге, сервис делает следующее:
- Если число критериев в запросе и в базе по данному `Task` совпадает, то он переносит данные из запроса и сохраняет изменения.
- Если число критериев в запросе больше, чем в базе по данному `Task`, то он переносит данные, пока есть, куда переносить, а оставшиеся критерии объявляет как новые и создает в базе.
- Если число критериев в запросе меньше, чем в базе по данному `Task`, то он переносит данные, пока есть, что переносить, а оставшиеся критерии удаляет.

Особое внимаение было уделено ситуации, когда мы у двух критериев имена меняем местами. Ради этого был создан дополнительный `CustomCriteriaRepository`.